### PR TITLE
cmip6 shell: state setup dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ ES-DOC software engineers.
 How to install cmip6 ?
 --------------------------------------
 
+Note that [`pyenv`](https://github.com/pyenv/pyenv) and
+[`pipenv`](https://pipenv.pypa.io/en/latest/) must be installed on your
+machine for the following commands to succeed.
+
 ```
 # Set repo.
 cd YOUR_WORKING_DIRECTORY


### PR DESCRIPTION
@momipsl this is quick PR to fix one typo I found when setting up `cmip6`. Plus, since I don't use `pyvenv` or `pipenv` outside of ES-DOC and had to install those for my laptop, I thought it could also be good to include a sentence to pre-warn on those package requirements.