### PR TITLE
Create machine CIM document from spreadsheet inputs

### DIFF
--- a/lib/machines/generate_cim_via_json.py
+++ b/lib/machines/generate_cim_via_json.py
@@ -605,5 +605,19 @@ if __name__ == '__main__':
     # Extract CIM
     cim_outputs = generate_cim_outputs(open_spreadsheet)
 
+    # Test serlialisation...
+    for cim_out in cim_outputs:
+        j = pyesdoc.encode(cim_out, "json")
+        ###print("FINAL OUTPUT IS")
+        ###pprint(j)
+        assert json.loads(j)
+        # TODO decoding broken below...
+        ### assert isinstance(pyesdoc.decode(j, "json"), cim.Machine)
+
+        x = pyesdoc.encode(cim_out, "xml")
+        # TODO, fix XML decoding errors like:
+        # "Scalar decoding error 2.7 GHz <type 'float'>"
+        assert isinstance(pyesdoc.decode(x, "xml"), cim.Machine)
+
     # Close template
     open_spreadsheet.close()

--- a/lib/machines/generate_cim_via_json.py
+++ b/lib/machines/generate_cim_via_json.py
@@ -15,6 +15,9 @@ from pprint import pprint
 
 from openpyxl import load_workbook
 
+import pyesdoc
+from pyesdoc.ontologies.cim import v2 as cim
+
 
 LABEL_COLUMN = 0  # i.e. index in A-Z of columns as tuple, so "A"
 INPUT_COLUMN = 1  # i.e. "B"
@@ -397,6 +400,30 @@ def generate_cim_outputs(machines_spreadsheet):
         machine_cim_outputs.append(cim)
 
     return machine_cim_outputs
+
+
+def init_machine_cim():
+    """TODO."""
+    # Define the overall document which will be populated below
+    machine_cim = pyesdoc.create(cim.Machine, **KWARGS)
+
+    # First-level properties, being their own platform classes
+    partition_cim = pyesdoc.create(cim.Partition, **KWARGS)
+
+    # Create two compute pools and storage pools, since the machine
+    # spreadsheet assumption was that there would be no more than two of
+    # either of these. If only one of either is described, the other is
+    # removed later when it becomes known to not be applicable.
+    compute_pools_cim_1 = pyesdoc.create(cim.ComputePool, **KWARGS)
+    compute_pools_cim_2 = pyesdoc.create(cim.ComputePool, **KWARGS)
+    storage_pools_cim_1 = pyesdoc.create(cim.StoragePool, **KWARGS)
+    storage_pools_cim_2 = pyesdoc.create(cim.StoragePool, **KWARGS)
+
+    # Connect the first-level properties to the top-level machine document
+    machine_cim.partition = partition_cim
+    machine_cim.compute_pools = [compute_pools_cim_1, compute_pools_cim_2]
+    machine_cim.storage_pools = [storage_pools_cim_1, storage_pools_cim_2]
+    return machine_cim
 
 
 # Main entry point.

--- a/lib/machines/generate_cim_via_json.py
+++ b/lib/machines/generate_cim_via_json.py
@@ -125,6 +125,66 @@ WS_QUESTIONS_TO_INPUT_CELLS_MAPPING = {
     # All (1, 9, 2, N) is processed in below
 }
 
+INSTITUTE = "an institute"  # TODO: hook up to CLI
+KWARGS = {
+    "project": "CMIP6",
+    "source": "spreadsheet",
+    "version": 1,
+    "institute": INSTITUTE
+}
+
+QUESTIONS_TO_CIM_MAPPING = {
+    # Identity:
+    (1, 1, 1): ("name",),
+    (1, 1, 2): ("partition", "name"),
+    # General properties:
+    (1, 2, 1): ("institution",),
+    (1, 2, 2): ("description",),
+    (1, 2, 3): ("online_documentation",),
+    (1, 2, 4): ("when_used",),
+    # Vendor information:
+    (1, 3, 1): ("vendor",),
+    (1, 3, 2): ("model_number",),
+    # Compute pools...
+    # Compute pool 1:
+    (1, 4, 1, 1): ("compute_pools", "name"),
+    (1, 4, 1, 2): ("compute_pools", "description"),
+    (1, 4, 1, 4): ("compute_pools", "model_number"),
+    (1, 4, 1, 5): ("compute_pools", "number_of_nodes"),
+    (1, 4, 1, 6): ("compute_pools", "memory_per_node"),
+    (1, 4, 1, 7): ("compute_pools", "compute_cores_per_node"),
+    (1, 4, 1, 9): ("compute_pools", "accelerators_per_node"),
+    (1, 4, 1, 10): ("compute_pools", "accelerator_type"),
+    (1, 4, 1, 11): ("compute_pools", "cpu_type"),
+    (1, 4, 1, 12): ("compute_pools", "clock_speed"),
+    (1, 4, 1, 13): ("compute_pools", "clock_cycle_concurrency"),
+    # Compute pool 2:
+    (1, 4, 2, 1): ("compute_pools", "name"),
+    (1, 4, 2, 2): ("compute_pools", "description"),
+    (1, 4, 2, 4): ("compute_pools", "model_number"),
+    (1, 4, 2, 5): ("compute_pools", "number_of_nodes"),
+    (1, 4, 2, 6): ("compute_pools", "memory_per_node"),
+    (1, 4, 2, 7): ("compute_pools", "compute_cores_per_node"),
+    (1, 4, 2, 9): ("compute_pools", "accelerators_per_node"),
+    (1, 4, 2, 10): ("compute_pools", "accelerator_type"),
+    (1, 4, 2, 11): ("compute_pools", "cpu_type"),
+    (1, 4, 2, 12): ("compute_pools", "clock_speed"),
+    (1, 4, 2, 13): ("compute_pools", "clock_cycle_concurrency"),
+    # Storage pools...
+    # Storage pool 1:
+    (1, 5, 1, 1): ("storage_pools", "name"),
+    (1, 5, 1, 3): ("storage_pools", "description"),
+    (1, 5, 1, 4): ("storage_pools", "type"),
+    (1, 5, 1, 5): ("storage_pools", "vendor"),
+    # Storage pool 2:
+    (1, 5, 2, 1): ("storage_pools", "name"),
+    (1, 5, 2, 3): ("storage_pools", "description"),
+    (1, 5, 2, 4): ("storage_pools", "type"),
+    (1, 5, 2, 5): ("storage_pools", "vendor"),
+    # Interconnect:
+    (1, 6, 1): ("compute_pools", "interconnect"),
+}
+
 
 def get_ws_questions_to_input_cells_mapping():
     input_labels = WS_QUESTIONS_TO_INPUT_CELLS_MAPPING.copy()

--- a/lib/machines/generate_cim_via_json.py
+++ b/lib/machines/generate_cim_via_json.py
@@ -19,6 +19,8 @@ import pyesdoc
 from pyesdoc.ontologies.cim import v2 as cim
 
 
+PRINT_WARNINGS = False
+
 LABEL_COLUMN = 0  # i.e. index in A-Z of columns as tuple, so "A"
 INPUT_COLUMN = 1  # i.e. "B"
 
@@ -145,6 +147,7 @@ QUESTIONS_TO_CIM_MAPPING = {
     (1, 2, 2): ("description",),
     (1, 2, 3): ("online_documentation",),
     (1, 2, 4): ("when_used",),
+    ### (1, 2, 5): ("operating_system",),  # TODO CIM V2.0 -> V2.2
     # Vendor information:
     (1, 3, 1): ("vendor",),
     (1, 3, 2): ("model_number",),
@@ -152,10 +155,21 @@ QUESTIONS_TO_CIM_MAPPING = {
     # Compute pool 1:
     (1, 4, 1, 1): ("compute_pools", "name"),
     (1, 4, 1, 2): ("compute_pools", "description"),
+    ### (1, 4, 1, 3): ("compute_pools", "vendor"),  # TODO CIM V2.0 -> V2.2
     (1, 4, 1, 4): ("compute_pools", "model_number"),
     (1, 4, 1, 5): ("compute_pools", "number_of_nodes"),
     (1, 4, 1, 6): ("compute_pools", "memory_per_node"),
     (1, 4, 1, 7): ("compute_pools", "compute_cores_per_node"),
+    # TODO CIM V2.0 -> V2.2, NIC component:
+    ### (1, 4, 1, 8, 1, 1): ("compute_pools", "nic", "name"),
+    ### (1, 4, 1, 8, 1, 2): ("compute_pools", "nic", "bandwidth"),
+    ### (1, 4, 1, 8, 1, 3): ("compute_pools", "nic", "vendor"),
+    ### (1, 4, 1, 8, 2, 1): ("compute_pools", "nic", "name"),
+    ### (1, 4, 1, 8, 2, 2): ("compute_pools", "nic", "bandwidth"),
+    ### (1, 4, 1, 8, 2, 3): ("compute_pools", "nic", "vendor"),
+    ### (1, 4, 1, 8, 3, 1): ("compute_pools", "nic", "name"),
+    ### (1, 4, 1, 8, 3, 2): ("compute_pools", "nic", "bandwidth"),
+    ### (1, 4, 1, 8, 3, 3): ("compute_pools", "nic", "vendor"),
     (1, 4, 1, 9): ("compute_pools", "accelerators_per_node"),
     (1, 4, 1, 10): ("compute_pools", "accelerator_type"),
     (1, 4, 1, 11): ("compute_pools", "cpu_type"),
@@ -164,10 +178,21 @@ QUESTIONS_TO_CIM_MAPPING = {
     # Compute pool 2:
     (1, 4, 2, 1): ("compute_pools", "name"),
     (1, 4, 2, 2): ("compute_pools", "description"),
+    ###(1, 4, 2, 3): ("compute_pools", "vendor"),  # TODO CIM V2.0 -> V2.2
     (1, 4, 2, 4): ("compute_pools", "model_number"),
     (1, 4, 2, 5): ("compute_pools", "number_of_nodes"),
     (1, 4, 2, 6): ("compute_pools", "memory_per_node"),
     (1, 4, 2, 7): ("compute_pools", "compute_cores_per_node"),
+    # TODO CIM V2.0 -> V2.2, NIC component:
+    ### (1, 4, 2, 8, 1, 1): ("compute_pools", "nic", "name"),
+    ### (1, 4, 2, 8, 1, 2): ("compute_pools", "nic", "bandwidth"),
+    ### (1, 4, 2, 8, 1, 3): ("compute_pools", "nic", "vendor"),
+    ### (1, 4, 2, 8, 2, 1): ("compute_pools", "nic", "name"),
+    ### (1, 4, 2, 8, 2, 2): ("compute_pools", "nic", "bandwidth"),
+    ### (1, 4, 2, 8, 2, 3): ("compute_pools", "nic", "vendor"),
+    ### (1, 4, 2, 8, 3, 1): ("compute_pools", "nic", "name"),
+    ### (1, 4, 2, 8, 3, 2): ("compute_pools", "nic", "bandwidth"),
+    ### (1, 4, 2, 8, 3, 3): ("compute_pools", "nic", "vendor"),
     (1, 4, 2, 9): ("compute_pools", "accelerators_per_node"),
     (1, 4, 2, 10): ("compute_pools", "accelerator_type"),
     (1, 4, 2, 11): ("compute_pools", "cpu_type"),
@@ -176,16 +201,28 @@ QUESTIONS_TO_CIM_MAPPING = {
     # Storage pools...
     # Storage pool 1:
     (1, 5, 1, 1): ("storage_pools", "name"),
+    # TODO CIM V2.0 -> V2.2:
+    ### (1, 5, 1, 2): ("storage_pools", "file_system_sizes"),
     (1, 5, 1, 3): ("storage_pools", "description"),
     (1, 5, 1, 4): ("storage_pools", "type"),
     (1, 5, 1, 5): ("storage_pools", "vendor"),
     # Storage pool 2:
     (1, 5, 2, 1): ("storage_pools", "name"),
+    # TODO CIM V2.0 -> V2.2:
+    ### (1, 5, 2, 2): ("storage_pools", "file_system_sizes"),
     (1, 5, 2, 3): ("storage_pools", "description"),
     (1, 5, 2, 4): ("storage_pools", "type"),
     (1, 5, 2, 5): ("storage_pools", "vendor"),
     # Interconnect:
-    (1, 6, 1): ("compute_pools", "interconnect"),
+    # TODO third level:
+    ### (1, 6, 1): ("compute_pools", "interconnect", "name"),
+    ### (1, 6, 2): ("compute_pools", "interconnect", "topology"),
+    ### (1, 6, 3): ("compute_pools", "interconnect", "description"),
+    ### (1, 6, 4): ("compute_pools", "interconnect", "vendor"),
+    # Benchmark performance:
+    # TODO CIM V2.0 -> V2.2:
+    ### (1, 7, 1): ("peak_performance",),
+    ### (1, 7, 2): ("linpack_performance",),
 }
 
 
@@ -235,8 +272,9 @@ def find_input_cells(spreadsheet_tab, input_labels):
                 # Handle special cases of input cell(s) offsets:
                 if isinstance(offset, str):
                     case = offset.lstrip("SPECIAL CASE: ")
-                    print("Treating a special case for the offset of:",
-                          label, "with rule:", case)
+                    if PRINT_WARNINGS:
+                        print("Treating a special case for the offset of:",
+                              label, "with rule:", case)
                     if case.endswith("+"):
                         offsets = []
                         check_cell_at_offset = int(case.rstrip("+"))
@@ -279,7 +317,8 @@ def find_input_cells(spreadsheet_tab, input_labels):
             if label.startswith("1.9.2.") or label.startswith("1.8.2."):
                 # Numbers not valid in this case, too few objects, so it
                 # we can just skip these...
-                print("Inapplicable model or MIP number skipped:", label)
+                if PRINT_WARNINGS:
+                    print("Inapplicable model or MIP number skipped:", label)
 
 
     return label_to_input_cell_mapping
@@ -352,10 +391,11 @@ def convert_tab_to_dict(spreadsheet_tab):
                         final_dict[label] = str(user_input)
                     except:
                         # Python 2 only unicode-escape
-                        print(
-                            "WARNING: Python 2 only unicode issue with:",
-                            label
-                        )
+                        if PRINT_WARNINGS:
+                            print(
+                                "WARNING: Python 2 only unicode issue with:",
+                                label
+                            )
                         final_dict[label] = user_input
         elif label.startswith("1.9.2."):
             if not spreadsheet_tab.cell(
@@ -467,11 +507,11 @@ def generate_cim_outputs(machines_spreadsheet):
 
     tabs = get_machine_tabs(machines_spreadsheet)
     for machine_tab in tabs:
-        print("CONVERTING TAB:")
-        pprint(machine_tab)
+        ###print("CONVERTING TAB:")
+        ###pprint(machine_tab)
         dict_out = convert_tab_to_dict(machine_tab)
-        print("INTERMEDIATE DICT IS:")
-        pprint(dict_out)
+        ###print("INTERMEDIATE DICT IS:")
+        ###pprint(dict_out)
         cim = convert_intermediate_dict_to_cim(dict_out)
         print("CIM IS:")
         pprint(cim)

--- a/lib/machines/generate_cim_via_json.py
+++ b/lib/machines/generate_cim_via_json.py
@@ -377,31 +377,6 @@ def convert_tab_to_dict(spreadsheet_tab):
     return final_dict
 
 
-def convert_intermediate_dict_to_cim(json):
-    """TODO."""
-    std_json = None
-    return std_json
-
-
-def generate_cim_outputs(machines_spreadsheet):
-    """TODO."""
-    machine_cim_outputs = []
-
-    tabs = get_machine_tabs(machines_spreadsheet)
-    for machine_tab in tabs:
-        print("CONVERTING TAB:")
-        pprint(machine_tab)
-        dict_out = convert_tab_to_dict(machine_tab)
-        print("INTERMEDIATE DICT IS:")
-        pprint(dict_out)
-        cim = convert_intermediate_dict_to_cim(dict_out)
-        print("CIM IS:")
-        pprint(cim)
-        machine_cim_outputs.append(cim)
-
-    return machine_cim_outputs
-
-
 def init_machine_cim():
     """TODO."""
     # Define the overall document which will be populated below
@@ -481,11 +456,44 @@ def map_question_inputs_to_machine_cim(inputs_by_question_number_json):
     return machine_doc
 
 
+def convert_intermediate_dict_to_cim(intermediate_dict):
+    """TODO."""
+    return map_question_inputs_to_machine_cim(intermediate_dict)
+
+
+def generate_cim_outputs(machines_spreadsheet):
+    """TODO."""
+    machine_cim_outputs = []
+
+    tabs = get_machine_tabs(machines_spreadsheet)
+    for machine_tab in tabs:
+        print("CONVERTING TAB:")
+        pprint(machine_tab)
+        dict_out = convert_tab_to_dict(machine_tab)
+        print("INTERMEDIATE DICT IS:")
+        pprint(dict_out)
+        cim = convert_intermediate_dict_to_cim(dict_out)
+        print("CIM IS:")
+        pprint(cim)
+
+        print("\n*** INSPECT MACHINE CIM DOC TO CHECK IT LOOKS OK ***\n")
+        pprint(cim.__dict__)
+        pprint(cim.partition.__dict__)
+        pprint(cim.compute_pools[0].__dict__)
+        pprint(cim.compute_pools[1].__dict__)
+        pprint(cim.storage_pools[0].__dict__)
+        pprint(cim.storage_pools[1].__dict__)
+
+        machine_cim_outputs.append(cim)
+
+    return machine_cim_outputs
+
+
 # Main entry point.
 if __name__ == '__main__':
     # Locate and open template
     spreadsheet_path = os.path.join(
-        "test-machine-sheets", "ipsl_real_submission.xlsx"
+        "test-machine-sheets", "cmcc_real_submission.xlsx"
     )  # TODO, TEMP: for testing
     open_spreadsheet = load_workbook(filename=spreadsheet_path)
 


### PR DESCRIPTION
This PR submits code (developed back in June) to convert the data structure mapping inputs to CIM components from #11 into a machine CIM document, barring some follow-on work to be submitted as further PRs.

Notably the main TODOs after this PR were:
* passing validation of the resultant machine CIM output, in turn to remove encoding or decoding errors;
* including platform elements from CIM v2.2 rather than just v2.0, the latter being currently processed by the standard install of `pyesdoc` though it is lacking some components relied on for the final publicised machine spreadsheet;
* further tidying, consolidation and modularisation of the code;

and 'archival' PRs for all of these will be raised and merged shortly.
