### PR TITLE
Validation & associations for created machine CIM documents

### DIFF
--- a/lib/machines/generate_cim_via_json.py
+++ b/lib/machines/generate_cim_via_json.py
@@ -440,14 +440,18 @@ def convert_tab_to_dict(spreadsheet_tab):
     return final_dict
 
 
-def convert_str_type_to_cim_type(dicts_of_inputs):
+def convert_str_type_to_cim_type(dicts_of_inputs, _print=True):
     """TODO."""
     inputs_with_cim_type = []
 
     for input_dict in dicts_of_inputs:
         input_with_cim_type = {}
-        print("RUNNING WITH", input_dict)
-        for q_no, q_answer in input_dict.items():
+        # Filter out inputs where no value was specified, by marker
+        submitted_inputs = {
+            q_no: val for q_no, val in input_dict.items() if
+            val != EMPTY_CELL_MARKER
+        }
+        for q_no, q_answer in submitted_inputs.items():
             str_q_no = convert_question_number_str_to_tuple(q_no)
             # If the type is not correct it must be converted accordingly
             if str_q_no in WS_QUESTIONS_WITH_NON_STRING_TYPE:
@@ -455,12 +459,14 @@ def convert_str_type_to_cim_type(dicts_of_inputs):
                 if not isinstance(q_answer, req_type):
                     try:  # attempt conversion to correct CIM type
                         q_answer = req_type(q_answer)
-                        print("%%%%%%%%%%%% CONVERTED", q_answer, "TO ",
-                              req_type)
+                        if _print:
+                            print("Converted {} from string to {}".format(
+                                q_answer, req_type))
                     except (ValueError, TypeError):
                         raise TypeError(
                             "Input to question {} cannot be converted to the "
-                            "required type {}.".format(q_no, req_type)
+                            "required type {}: {}.".format(
+                                q_no, req_type, q_answer)
                         )
 
             input_with_cim_type[q_no] = q_answer
@@ -514,17 +520,12 @@ def convert_question_number_str_to_tuple(q_no):
 
 def get_inputs_and_mapping_to_cim(inputs_by_question_number_json):
     """TODO."""
-    # Filter out inputs where no value was specified, by marker
-    submitted_inputs = {
-        q_no: val for q_no, val in inputs_by_question_number_json.items() if
-        val != EMPTY_CELL_MARKER
-    }
-    # Change tuple of int question numebr labels to dot-delimited string
+    # Change tuple of int question number labels to dot-delimited string
     questions_to_cim_mapping_str = {
         convert_question_number_tuple_to_str(q_no): val for q_no, val in
         QUESTIONS_TO_CIM_MAPPING.items()
     }
-    return submitted_inputs, questions_to_cim_mapping_str
+    return inputs_by_question_number_json, questions_to_cim_mapping_str
 
 
 def get_machine_doc(inputs_by_question_number_json):

--- a/lib/machines/generate_cim_via_json.py
+++ b/lib/machines/generate_cim_via_json.py
@@ -769,8 +769,10 @@ def get_applicable_experiments(intermediate_dict):
         pass
     elif all_applicable == "SOME":
         # In this case must filter out ones specified as not being applicable
+        given_exps = [
+            exp for exp in exp_with_appl if exp is not "NONE"]
         applicable_exps = {
-            appl.keys()[0]: appl.values()[0] for appl in exp_with_appl if
+            appl.keys()[0]: appl.values()[0] for appl in given_exps if
             appl.values()[0] != ["NONE"]
         }
         # TODO for rigour, add test to check for any weird inputs, e.g. None
@@ -813,7 +815,7 @@ def convert_ws_to_inputs(ws_location):
 if __name__ == '__main__':
     inputs, two_c_pools, two_s_pools = convert_ws_to_inputs(
         os.path.join(
-            "test-machine-sheets", "ipsl_real_submission.xlsx"
+            "test-machine-sheets", "cmcc_real_submission.xlsx"
     ))  # TODO: hook up location to CLI, this WS is just for testing purposes
 
     # Iterate over all machine tabs to get all sets of outputs

--- a/lib/machines/generate_cim_via_json.py
+++ b/lib/machines/generate_cim_via_json.py
@@ -626,18 +626,18 @@ def filter_out_excess_pool(intermediate_dicts, q_no_start):
     filtered_dicts = []
 
     # Determine if a second pool has been described
-    second_pool_described = False
-    for int_dict in intermediate_dicts:
+    second_pool_described = [False] * len(intermediate_dicts)
+    for index, int_dict in enumerate(intermediate_dicts):
         for q_no, q_answer in int_dict.items():
             if (not q_no.startswith(
                     convert_question_number_tuple_to_str(q_no_start))):
                 continue
-                if (q_answer != EMPTY_CELL_MARKER and
-                    q_answer != ([EMPTY_CELL_MARKER])):
-                    second_pool_described = True
+            if (q_answer != EMPTY_CELL_MARKER and
+                q_answer != ([EMPTY_CELL_MARKER])):
+                second_pool_described[index] = True
 
         # If the second pool has not been provided, filter out that question
-        if not second_pool_described:
+        if not second_pool_described[index]:
             filtered_dicts.append(
                 {
                     q_no: q_ans for q_no, q_ans in int_dict.items() if
@@ -731,10 +731,12 @@ if __name__ == '__main__':
         filtered_inputs_dicts)
 
     # Iterate over all machine tabs to get all sets of outputs
-    for input_dict in type_converted_inputs_dicts:
+    for index, input_dict in enumerate(type_converted_inputs_dicts):
         # Return machine doc with applicable models and experiments:
         cim_out, apply_models_out, appl_exp_out = generate_outputs(
-            input_dict, two_c_pools=two_c_pools, two_s_pools=two_s_pools)
+            input_dict, two_c_pools=two_c_pools[index],
+            two_s_pools=two_s_pools[index]
+        )
 
         # Validate the CIM document
         # TODO invalid, fix this!

--- a/lib/machines/generate_cim_via_json.py
+++ b/lib/machines/generate_cim_via_json.py
@@ -464,7 +464,7 @@ def convert_tab_to_dict(spreadsheet_tab):
 
 
 def convert_str_type_to_cim_type(
-        dicts_of_inputs, error_when_fail_type_conv=False, _print=True):
+        dicts_of_inputs, error_when_fail_type_conv=False, _print=False):
     """TODO."""
     inputs_with_cim_type = []
 
@@ -581,11 +581,9 @@ def set_cim_component(q_no, component, attribute_to_set, value_to_set):
         # Set an association
         association = pyesdoc.associate_by_name(
             component, cim_object, value_to_set)
-        print("SETTING ASSOC", component, attribute_to_set, association)
         setattr(component, attribute_to_set, association)
     else:
         # Set an attribute
-        print("SETTING attr", component, attribute_to_set)
         setattr(component, attribute_to_set, value_to_set)
 
 
@@ -621,9 +619,8 @@ def get_machine_doc(inputs_by_question_number_json, two_c_pools, two_s_pools):
                         "linkage", q_answer[0]
                     )
                 elif comp == "when_used":  # special case 2
-                    print("WU VALUES ARE", q_no, machine_doc, comp, q_answer)
                     set_cim_component(
-                        q_no, machine_doc, comp, "When used")  #q_answer)
+                        q_no, machine_doc, comp, "When used")
                     if q_answer[0] != EMPTY_CELL_MARKER:
                         setattr(
                             getattr(machine_doc, comp),
@@ -690,7 +687,7 @@ def generate_intermediate_dict_outputs(machines_spreadsheet):
     return intermediate_dict_outputs
 
 
-def generate_outputs(machine_dict, two_c_pools, two_s_pools, _print=True):
+def generate_outputs(machine_dict, two_c_pools, two_s_pools, _print=False):
     """TODO."""
     # Get the machine CIM document and applicable models and experiments
     cim_doc = get_machine_doc(machine_dict, two_c_pools, two_s_pools)
@@ -827,18 +824,12 @@ if __name__ == '__main__':
             two_s_pools=two_s_pools[index]
         )
 
-        print("\n*** INSPECT MACHINE CIM DOC TO CHECK IT LOOKS OK ***\n")
-        print(type(cim_out))
-        pprint(cim_out.__dict__)
-        pprint(cim_out.compute_pools[0].__dict__)
-        pprint(cim_out.compute_pools[0].memory_per_node.__dict__)
-        pprint(cim_out.when_used)
-        pprint(cim_out.when_used.__dict__)
-        pprint(cim_out.online_documentation)
-        pprint(cim_out.online_documentation[0].__dict__)
-
         # Validate the CIM document - there should not be any errors
-        if not pyesdoc.is_valid(cim_out):
+        if pyesdoc.is_valid(cim_out):
+            print(
+                "Complete: machine CIM document generated and is valid.")
+        else:
+            print("Machine CIM document generated is not valid:")
             for err in pyesdoc.validate(cim_out):
                 print(err)
 

--- a/lib/machines/generate_cim_via_json.py
+++ b/lib/machines/generate_cim_via_json.py
@@ -461,7 +461,6 @@ def convert_str_type_to_cim_type(
             q_no: val for q_no, val in input_dict.items() if
             val != EMPTY_CELL_MARKER and val != [EMPTY_CELL_MARKER]
         }
-        print("INPUTS ARE:", submitted_inputs)
         for q_no, q_answer in submitted_inputs.items():
             str_q_no = convert_question_number_str_to_tuple(q_no)
             # If the type is not correct it must be converted accordingly
@@ -703,13 +702,10 @@ def get_applicable_experiments(intermediate_dict):
     return applicable_exps
 
 
-# Main entry point.
-if __name__ == '__main__':
+def convert_ws_to_inputs(ws_location):
+    """TODO."""
     # Locate and open template
-    spreadsheet_path = os.path.join(
-        "test-machine-sheets", "ipsl_real_submission.xlsx"
-    )  # TODO, TEMP: for testing
-    open_spreadsheet = load_workbook(filename=spreadsheet_path)
+    open_spreadsheet = load_workbook(filename=ws_location)
 
     # Extract inputs to spreadsheet as outputs ready to add to the CIM
     inputs_dicts = generate_intermediate_dict_outputs(open_spreadsheet)
@@ -730,8 +726,18 @@ if __name__ == '__main__':
     type_converted_inputs_dicts = convert_str_type_to_cim_type(
         filtered_inputs_dicts)
 
+    return type_converted_inputs_dicts, two_c_pools, two_s_pools
+
+
+# Main entry point.
+if __name__ == '__main__':
+    inputs, two_c_pools, two_s_pools = convert_ws_to_inputs(
+        os.path.join(
+            "test-machine-sheets", "ipsl_real_submission.xlsx"
+    ))  # TODO: hook up location to CLI, this WS is just for testing purposes
+
     # Iterate over all machine tabs to get all sets of outputs
-    for index, input_dict in enumerate(type_converted_inputs_dicts):
+    for index, input_dict in enumerate(inputs):
         # Return machine doc with applicable models and experiments:
         cim_out, apply_models_out, appl_exp_out = generate_outputs(
             input_dict, two_c_pools=two_c_pools[index],

--- a/lib/machines/generate_cim_via_json.py
+++ b/lib/machines/generate_cim_via_json.py
@@ -511,7 +511,8 @@ def convert_str_type_to_cim_type(
     return inputs_with_cim_type
 
 
-def init_machine_cim(two_compute_pools=True, two_storage_pools=True):
+def init_machine_cim(
+        set_partition=False, two_compute_pools=True, two_storage_pools=True):
     """TODO."""
     kwargs = {
         "project": "CMIP6",
@@ -523,7 +524,8 @@ def init_machine_cim(two_compute_pools=True, two_storage_pools=True):
     machine_cim = pyesdoc.create(cim.Machine, **kwargs)
 
     # Connect the first-level properties to the top-level machine document
-    machine_cim.partition = pyesdoc.create(cim.Partition, **kwargs)
+    if set_partition:
+        machine_cim.partition = pyesdoc.create(cim.Partition, **kwargs)
     # TODO: list of given length, for now groups have all given len 1 answer
     machine_cim.online_documentation = [pyesdoc.create(
         cim.OnlineResource)]
@@ -595,6 +597,7 @@ def get_machine_doc(inputs_by_question_number_json, two_c_pools, two_s_pools):
     """TODO."""
 
     # Inititate machine CIM document
+    # TODO: manage multiple partitions via set_partition flag kwarg
     machine_doc = init_machine_cim(
         two_compute_pools=two_c_pools, two_storage_pools=two_s_pools)
     inputs, q_to_cim_mapping = get_inputs_and_mapping_to_cim(
@@ -803,8 +806,7 @@ if __name__ == '__main__':
         pprint(cim_out.__dict__)
         #pprint(cim_out.partition.__dict__)
         #pprint(cim_out.compute_pools[0].__dict__)
-        pprint(cim_out.storage_pools[0].__dict__)
-        print(cim_out.online_documentation[0].__dict__)
+        pprint(cim_out.compute_pools[0].__dict__)
 
         # Validate the CIM document
         # TODO invalid, fix this!


### PR DESCRIPTION
This PR submits code (developed back in September) to add type associations and generally further manage the construction of the machine CIM document such that, as an end goal achieved for the code covered by this PR, the machine documents generated from a variety of real group-submissions of machine spreadsheets passed validation and were successfully encoded and decoded.

Follow-on work has since been completed and will be submitted as further, fairly self-contained, PRs.